### PR TITLE
Update babel + react

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["babel-plugin-transform-object-rest-spread"],
+  "presets": ["react", "es2015"]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Redux-react-starter
 
-
 This project includes a basic starter boilerplate for our Redux + React + React-router projects, using webpack as a build system and babel for transpilation.
 
 Be sure to `npm install` first.
@@ -24,15 +23,10 @@ Be sure to `npm install` first.
 
 ## Production
 
-
 2. `npm run build` will build and uglify files to `dist/` ready to push to production.
 
 ### Todos:
 
-* Update react, react-router, redux and react-redux deps.
-* Update babel to v6
-* Remove lodash in favour for babel object spread (I believe babel-preset-react has this)
 * Add in react-redux-router over the top of react-router
 * Configure (and update) redux-devtools
 * Add some basic tests for the example, including example redux tests & example react tests
-

--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
 import configureStore from './redux/store';
@@ -7,8 +8,8 @@ import routes from './routes';
 const targetEl = document.getElementById('app');
 const store = configureStore();
 
-React.render((
+ReactDOM.render((
   <Provider store={store}>
-    {() => <Router routes={routes(store)} />}
+    <Router routes={routes(store)} />
   </Provider>
 ), targetEl);

--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router';
+import { Router, browserHistory } from 'react-router';
 import configureStore from './redux/store';
 import routes from './routes';
 
@@ -10,6 +10,6 @@ const store = configureStore();
 
 ReactDOM.render((
   <Provider store={store}>
-    <Router routes={routes(store)} />
+    <Router history={browserHistory} routes={routes(store)} />
   </Provider>
 ), targetEl);

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,12 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Main extends Component {
-  render() {
-    return (
-      <div>
-        <input type="text" onChange={this.props.onNameChange} />
-        <p> Hello {this.props.name} </p>
-      </div>
-    )
-  }
+export default function Main({ name, onNameChange }) {
+  return (
+    <div>
+      <input type="text" onChange={onNameChange} />
+      <p> Hello {name} </p>
+    </div>
+  )
 }

--- a/app/redux/reducers/hello.js
+++ b/app/redux/reducers/hello.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { CHANGE_NAME } from '../actions/hello';
 
 const initialState = {
@@ -8,9 +7,8 @@ const initialState = {
 export function hello(state = initialState, action) {
   switch (action.type) {
     case CHANGE_NAME:
-      return _.assign({}, state, {
-        name: action.name
-      });
+      return { ...state, name: action.name };
+      break
     default:
       return state;
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^3.10.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
-    "react-redux": "^2.1.2",
+    "react-redux": "^4.4.1",
     "react-router": "^1.0.0-rc1",
     "redux": "^3.0.0",
     "redux-devtools": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -19,23 +19,26 @@
   },
   "homepage": "https://github.com/Prismatik/redux-react-starter",
   "devDependencies": {
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.7.2",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "file-loader": "^0.8.4",
     "react-hot-loader": "^1.3.0",
-    "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.11.0"
+    "webpack": "^1.12.14",
+    "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "history": "^2.0.1",
     "lodash": "^4.6.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.1",
-    "react-router": "^1.0.0-rc1",
+    "react-router": "^2.0.1",
     "redux": "^3.0.0",
-    "redux-devtools": "^2.1.2",
-    "redux-logger": "^1.0.8",
-    "redux-thunk": "^1.0.0"
+    "redux-devtools": "^3.1.1",
+    "redux-logger": "^2.6.1",
+    "redux-thunk": "^2.0.1"
   },
   "engine": "node 4.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "react": "^0.13.3",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
     "react-redux": "^2.1.2",
     "react-router": "^1.0.0-rc1",
     "redux": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "history": "^2.0.1",
-    "lodash": "^4.6.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "webpack-dev-server": "^1.11.0"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash": "^4.6.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var environments = {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loaders: ['react-hot', 'babel-loader'],
+          loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015'],
         },
         {
           test: /\.html$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var environments = {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015,plugins[]=babel-plugin-transform-object-rest-spread'],
+          loaders: ['react-hot', 'babel'],
         },
         {
           test: /\.html$/,
@@ -42,7 +42,7 @@ var environments = {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loaders: ['babel-loader'],
+          loaders: ['babel'],
         },
         {
           test: /\.html$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var environments = {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015'],
+          loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015,plugins[]=babel-plugin-transform-object-rest-spread'],
         },
         {
           test: /\.html$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var environments = {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loaders: ['react-hot', 'babel'],
+          loaders: ['react-hot', 'babel']
         },
         {
           test: /\.html$/,


### PR DESCRIPTION
This branch addresses:
- Update React et al to latest versions
- Update Babel 5 -> 6
- Add `.babelrc` config
- Update codebase per React 0.14 eg. remove anonymous `function` with `Provider`, use stateless component for `Main`..
- Remove `lodash` (only used for `_.assign`) in favour of babel rest transform for reducers
- Default router to browser history, not hash
